### PR TITLE
to compatible with old version

### DIFF
--- a/security/cipher.go
+++ b/security/cipher.go
@@ -1,0 +1,24 @@
+/*Copyright 2017 Huawei Technologies Co., Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *    http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package security is deprecated plz use github.com/go-chassis/cari/security
+package security
+
+//Cipher interface declares two function for encryption and decryption
+type Cipher interface {
+	Encrypt(src string) (string, error)
+
+	Decrypt(src string) (string, error)
+}

--- a/string/string.go
+++ b/string/string.go
@@ -1,0 +1,82 @@
+//Package stringutil is deprecated, plz use github.com/go-chassis/foundation/stringutil instead
+package stringutil
+
+import (
+	"strings"
+	"unsafe"
+)
+
+// Deprecated StringInSlice convert string to bool
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// Deprecated Str2bytes convert string to array of byte
+func Str2bytes(s string) []byte {
+	x := (*[2]uintptr)(unsafe.Pointer(&s))
+	h := [3]uintptr{x[0], x[1], x[1]}
+	return *(*[]byte)(unsafe.Pointer(&h))
+}
+
+// Deprecated Bytes2str convert array of byte to string
+func Bytes2str(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+// Deprecated SplitToTwo split the string
+func SplitToTwo(s, sep string) (string, string) {
+	index := strings.Index(s, sep)
+	if index < 0 {
+		return "", s
+	}
+	return s[:index], s[index+len(sep):]
+}
+
+// Deprecated SplitFirstSep split the string
+func SplitFirstSep(s, sep string) string {
+	index := strings.Index(s, sep)
+	if index < 0 {
+		return ""
+	}
+	return s[:index]
+}
+
+// Deprecated MinInt check the minimum value of two integers
+func MinInt(x, y int) int {
+	if x <= y {
+		return x
+	}
+
+	return y
+}
+
+// Deprecated ClearStringMemory clear string memory, for very sensitive security related data
+//you should clear it in memory after use
+func ClearStringMemory(src *string) {
+	p := (*struct {
+		ptr uintptr
+		len int
+	})(unsafe.Pointer(src))
+
+	len := MinInt(p.len, 32)
+	ptr := p.ptr
+	for idx := 0; idx < len; idx = idx + 1 {
+		b := (*byte)(unsafe.Pointer(&ptr))
+		*b = 0
+		ptr++
+	}
+}
+
+// Deprecated ClearByteMemory clear byte memory, for very sensitive security related data
+//you should clear it in memory after use
+func ClearByteMemory(src []byte) {
+	len := MinInt(len(src), 32)
+	for idx := 0; idx < len; idx = idx + 1 {
+		src[idx] = 0
+	}
+}

--- a/string/string_test.go
+++ b/string/string_test.go
@@ -1,0 +1,185 @@
+package stringutil_test
+
+import (
+	"container/list"
+	"strings"
+	"testing"
+
+	"github.com/go-chassis/foundation/string"
+	"github.com/stretchr/testify/assert"
+)
+
+var s = strings.Repeat("a", 1024)
+
+func TestClearByteMemory(t *testing.T) {
+	b := []byte("aaa")
+	assert.Equal(t, "aaa", string(b))
+	stringutil.ClearByteMemory(b)
+	assert.NotEqual(t, "aaa", string(b))
+}
+func TestMinInt(t *testing.T) {
+
+	a := stringutil.MinInt(1, 2)
+	assert.Equal(t, 1, a)
+
+	a = stringutil.MinInt(2, 1)
+	assert.Equal(t, 1, a)
+}
+func BenchmarkTest(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b := []byte(s)
+		_ = string(b)
+	}
+}
+
+func BenchmarkTestBlock(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b := []byte(s)
+		_ = stringutil.Bytes2str(b)
+	}
+}
+func BenchmarkTest1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = []byte(s)
+
+	}
+}
+
+func BenchmarkTestBlock2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = stringutil.Str2bytes("asd")
+	}
+}
+
+const capacity = 2
+
+func array() [capacity]int {
+	var d [capacity]int
+
+	for i := 0; i < len(d); i++ {
+		d[i] = 1
+	}
+
+	return d
+}
+
+func slice() []int {
+	d := make([]int, capacity)
+
+	for i := 0; i < len(d); i++ {
+		d[i] = 1
+	}
+
+	return d
+}
+
+var l *list.List
+
+func init() {
+	l = list.New()
+	for i := 0; i < capacity; i++ {
+		l.PushBack(i)
+	}
+}
+func List() {
+
+	for e := l.Front(); e != nil; e = e.Next() {
+		_ = e.Value.(int)
+	}
+
+}
+func BenchmarkArray(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = array()
+	}
+}
+
+func BenchmarkSlice(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = slice()
+	}
+
+}
+func BenchmarkList(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		List()
+	}
+
+}
+
+func TestStringFunc(t *testing.T) {
+
+	var strArr = []string{"abc", "def"}
+
+	b := stringutil.StringInSlice("abc", strArr)
+	assert.Equal(t, true, b)
+
+	b = stringutil.StringInSlice("wer", strArr)
+	assert.Equal(t, false, b)
+
+	by := stringutil.Str2bytes("abc")
+	str := stringutil.Bytes2str(by)
+
+	assert.Equal(t, str, string(by))
+}
+
+func TestSplitToTwo(t *testing.T) {
+	s1 := "aa"
+	s2 := "bb"
+	sub := "::"
+	s := s1 + sub + s2
+	p1, p2 := stringutil.SplitToTwo(s, sub)
+	assert.Equal(t, s1, p1)
+	assert.Equal(t, s2, p2)
+
+	p1, p2 = stringutil.SplitToTwo(s, "/")
+	assert.Empty(t, p1)
+	assert.Equal(t, s, p2)
+}
+
+func TestSplitFirstSep(t *testing.T) {
+	s1 := "aa"
+	s2 := "bb"
+	sub := "::"
+	s := s1 + sub + s2
+	p1 := stringutil.SplitFirstSep(s, sub)
+	assert.Equal(t, s1, p1)
+
+	p1 = stringutil.SplitFirstSep(s, "/")
+	assert.Empty(t, p1)
+}
+
+func SplitToTwoByStringsSplit(s, sep string) (string, string) {
+	r := strings.Split(s, sep)
+	return r[0], r[1]
+}
+
+func SplitFirstSepByStringsSplit(s, sep string) string {
+	return strings.Split(s, sep)[0]
+}
+
+var testURL = "http://127.0.0.1"
+
+func Benchmark_SplitToTwo(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stringutil.SplitToTwo(testURL, "://")
+	}
+}
+
+func Benchmark_SplitToTwoByStringsSplit(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = SplitToTwoByStringsSplit(testURL, "://")
+	}
+}
+
+func Benchmark_SplitFirstSep(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = stringutil.SplitFirstSep(testURL, "://")
+	}
+}
+
+func Benchmark_SplitFirstSepByStringsSplit(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = SplitFirstSepByStringsSplit(testURL, "://")
+	}
+}


### PR DESCRIPTION
archaius的1.4.0版本依赖高版本foundation，而go chassis2.0.0.alpha3依然以来低版本，要保持兼容，以便老版本的go chassis依然可以引用最新版本的archaius