### PR TITLE
Bugfix :decrypt is nil and plainpass should be assigned to password

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,4 +16,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
-          args: --skip-dirs=examples,tls --out-format=colored-line-number --skip-files=.*_test.go$
+          args: --skip-dirs=examples,tls --skip-files=.*_test.go$

--- a/tlsutil/tls.go
+++ b/tlsutil/tls.go
@@ -46,6 +46,8 @@ func LoadTLSCertificate(certFile, keyFile, password string, decrypt Decrypt) ([]
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			plainpass = password
 		}
 		if x509.IsEncryptedPEMBlock(keyBlock) {
 			keyData, err := x509.DecryptPEMBlock(keyBlock, []byte(plainpass))


### PR DESCRIPTION
If the decrypt is nil in the loadtlscertificate method, plainpass should be assigned as password