### PR TITLE
修改RegexValidateRule,使其能自定义explain

### DIFF
--- a/validator/rule.go
+++ b/validator/rule.go
@@ -8,8 +8,9 @@ import (
 
 // RegexValidateRule contains an validate tag's info
 type RegexValidateRule struct {
-	tag   string
-	regex *regexp.Regexp
+	tag     string
+	regex   *regexp.Regexp
+	explain string
 }
 
 // Validate validates string
@@ -28,8 +29,10 @@ func (r *RegexValidateRule) Tag() string {
 
 // Explain explains the rule
 func (r *RegexValidateRule) Explain() string {
-	explain := r.regex.String()
-	return explain
+	if r.explain != "" {
+		return r.explain
+	}
+	return r.regex.String()
 }
 
 // NewRegexRule news a rule
@@ -38,4 +41,10 @@ func NewRegexRule(tag, regexStr string) *RegexValidateRule {
 		tag:   tag,
 		regex: regexp.MustCompile(regexStr),
 	}
+}
+
+// WithExplain customize the explanation
+func (r *RegexValidateRule) WithExplain(explain string) *RegexValidateRule {
+	r.explain = explain
+	return r
 }

--- a/validator/rule_test.go
+++ b/validator/rule_test.go
@@ -17,4 +17,9 @@ func TestNewRule(t *testing.T) {
 	assert.True(t, rule.Validate("abcde"))
 	assert.True(t, rule.Validate("abcdefg12345678"))
 	assert.False(t, rule.Validate("ab-"))
+
+	// test NewRegexRule with explain
+	explanation := "some rule you don't want to expose"
+	rule1 := validator.NewRegexRule("t", `^[a-zA-Z0-9]*$`).WithExplain(explanation)
+	assert.Equal(t, explanation, rule1.Explain())
 }


### PR DESCRIPTION
正则校验后会返回错误，其错误信息是由 RegexValidateRule 的Explain()函数决定的。某些场景下，需要不在错误信息中展示出正则表达式，如：url校验，为避免恶意网络攻击，将url规则隐藏起来，这种情况自定义规则的explain。